### PR TITLE
[Feature] 모집 공고 상세 조회

### DIFF
--- a/src/main/java/com/likelionknu/applyserver/admin/controller/AdminRecruitController.java
+++ b/src/main/java/com/likelionknu/applyserver/admin/controller/AdminRecruitController.java
@@ -1,0 +1,22 @@
+package com.likelionknu.applyserver.admin.controller;
+
+import com.likelionknu.applyserver.admin.data.dto.response.AdminRecruitDetailResponse;
+import com.likelionknu.applyserver.admin.service.AdminRecruitService;
+import com.likelionknu.applyserver.common.response.GlobalResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/recruits")
+public class AdminRecruitController {
+
+    private final AdminRecruitService adminRecruitService;
+
+    @GetMapping("/{id}")
+    @Operation(summary = "모집 공고 상세 정보 조회")
+    public GlobalResponse<AdminRecruitDetailResponse> getRecruitDetail(@PathVariable Long id) {
+        return GlobalResponse.ok(adminRecruitService.getRecruitDetail(id));
+    }
+}

--- a/src/main/java/com/likelionknu/applyserver/admin/data/dto/response/AdminRecruitDetailResponse.java
+++ b/src/main/java/com/likelionknu/applyserver/admin/data/dto/response/AdminRecruitDetailResponse.java
@@ -1,0 +1,16 @@
+package com.likelionknu.applyserver.admin.data.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record AdminRecruitDetailResponse(
+        String title,
+        @JsonProperty("start_at") LocalDateTime startAt,
+        @JsonProperty("end_at") LocalDateTime endAt,
+        List<String> questions
+) {
+}

--- a/src/main/java/com/likelionknu/applyserver/admin/service/AdminRecruitService.java
+++ b/src/main/java/com/likelionknu/applyserver/admin/service/AdminRecruitService.java
@@ -1,0 +1,40 @@
+package com.likelionknu.applyserver.admin.service;
+
+import com.likelionknu.applyserver.admin.data.dto.response.AdminRecruitDetailResponse;
+import com.likelionknu.applyserver.recruit.data.entity.Recruit;
+import com.likelionknu.applyserver.recruit.data.entity.RecruitContent;
+import com.likelionknu.applyserver.recruit.data.repository.RecruitContentRepository;
+import com.likelionknu.applyserver.recruit.data.repository.RecruitRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminRecruitService {
+
+    private final RecruitRepository recruitRepository;
+    private final RecruitContentRepository recruitContentRepository;
+
+    public AdminRecruitDetailResponse getRecruitDetail(Long recruitId) {
+        Recruit recruit = recruitRepository.findById(recruitId)
+                .orElseThrow(() -> new IllegalStateException("모집 공고를 찾을 수 없습니다."));
+
+        List<RecruitContent> contents =
+                recruitContentRepository.findByRecruitIdOrderByPriorityAsc(recruitId);
+
+        List<String> questions = contents.stream()
+                .map(RecruitContent::getQuestion)
+                .toList();
+
+        return AdminRecruitDetailResponse.builder()
+                .title(recruit.getTitle())
+                .startAt(recruit.getStartAt())
+                .endAt(recruit.getEndAt())
+                .questions(questions)
+                .build();
+    }
+}

--- a/src/main/java/com/likelionknu/applyserver/recruit/data/repository/RecruitContentRepository.java
+++ b/src/main/java/com/likelionknu/applyserver/recruit/data/repository/RecruitContentRepository.java
@@ -4,8 +4,6 @@ import com.likelionknu.applyserver.recruit.data.entity.RecruitContent;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
-import java.util.List;
-
 public interface RecruitContentRepository extends JpaRepository<RecruitContent, Long> {
 
     List<RecruitContent> findByRecruitIdOrderByPriorityAsc(Long recruitId);


### PR DESCRIPTION
## 개요
- close #56 

## 작업사항
- 관리자 전용 모집 공고 상세 조회 API를 구현
- 모집 공고의 기본 정보와 질문 목록을 우선순위 기준으로 조회하도록 구성