### PR TITLE
[Feature] 특정 지원서 강제 삭제 기능 구현

### DIFF
--- a/src/main/java/com/likelionknu/applyserver/admin/controller/AdminController.java
+++ b/src/main/java/com/likelionknu/applyserver/admin/controller/AdminController.java
@@ -91,4 +91,11 @@ public class AdminController {
         adminApplicationService.patch(id, request);
         return GlobalResponse.ok();
     }
+
+    @DeleteMapping("/applications/{id}")
+    @Operation(summary = "특정 지원서 강제 삭제")
+    public GlobalResponse<Void> deleteAdminApplication(@PathVariable Long id) {
+        adminApplicationService.deleteAdminApplication(id);
+        return GlobalResponse.ok();
+    }
 }

--- a/src/main/java/com/likelionknu/applyserver/admin/service/AdminApplicationService.java
+++ b/src/main/java/com/likelionknu/applyserver/admin/service/AdminApplicationService.java
@@ -65,4 +65,11 @@ public class AdminApplicationService {
             updateEvaluation(applicationId, request.evaluation());
         }
     }
+
+    public void deleteAdminApplication(Long applicationId) {
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new ApplicationNotFoundException());
+
+        applicationRepository.delete(application);
+    }
 }


### PR DESCRIPTION
## 개요
- close #75

## 작업사항
- 지원서 강제 삭제 API 기능 구현 (지원서 상태와 무관하게 삭제 가능하도록 구현)
- 지원서 삭제 시 연관 답변(RecruitAnswer) 함께 삭제