### PR TITLE
[Bug] AdminRecruitSummaryResponse 생성자 타입 불일치 수정

### DIFF
--- a/src/main/java/com/likelionknu/applyserver/admin/data/dto/response/AdminRecruitSummaryResponse.java
+++ b/src/main/java/com/likelionknu/applyserver/admin/data/dto/response/AdminRecruitSummaryResponse.java
@@ -9,7 +9,7 @@ public record AdminRecruitSummaryResponse(
         String title,
         @JsonProperty("start_at") LocalDateTime startAt,
         @JsonProperty("end_at") LocalDateTime endAt,
-        int submit,
-        int draft
+        Long submit,
+        Long draft
 ) {
 }


### PR DESCRIPTION
## 개요
- close #89 

## 작업사항
- AdminRecruitSummaryResponse 생성자 타입 불일치 수정